### PR TITLE
Load meta data from remove server

### DIFF
--- a/Classes/Helpers/OpencastHelper.php
+++ b/Classes/Helpers/OpencastHelper.php
@@ -21,6 +21,8 @@ class OpencastHelper extends AbstractOnlineMediaHelper
         'play\/' . self::MEDIA_ID_PATTERN,
     ];
 
+    private static $cache = [];
+
     public function __construct($extension)
     {
         $this->extension = $extension;
@@ -183,14 +185,18 @@ class OpencastHelper extends AbstractOnlineMediaHelper
     protected function fetchJson($mediaId): ?array
     {
         if (preg_match('/' . self::MEDIA_ID_PATTERN . '/', $mediaId)) {
-            $url = $this->host . 'search/episode.json?id=' . $mediaId;
-            if ($json = GeneralUtility::getUrl($url)) {
-                $json = json_decode($json, true);
-                if (isset($json['search-results']['result']) &&
-                    is_array($json['search-results']['result'])) {
-                    return $json['search-results']['result'];
+            if (empty(self::$cache[$mediaId])) {
+                $url = $this->host . 'search/episode.json?id=' . $mediaId;
+                if ($json = GeneralUtility::getUrl($url)) {
+                    $json = json_decode($json, true);
+                    if (isset($json['search-results']['result']) &&
+                        is_array($json['search-results']['result'])) {
+                        self::$cache[$mediaId] = $json['search-results']['result'];
+                    }
                 }
             }
+
+            return self::$cache[$mediaId] ?? null;
         }
 
         return null;

--- a/Classes/Helpers/OpencastHelper.php
+++ b/Classes/Helpers/OpencastHelper.php
@@ -164,8 +164,7 @@ class OpencastHelper extends AbstractOnlineMediaHelper
     protected function getAttachments($mediaId): ?array
     {
         if ($data = $this->fetchJson($mediaId)) {
-            if (is_array($data['mediapackage']) &&
-                is_array($data['mediapackage']['attachments']) &&
+            if (isset($data['mediapackage']['attachments']['attachment']) &&
                 is_array($data['mediapackage']['attachments']['attachment'])) {
                 return $data['mediapackage']['attachments']['attachment'];
             }
@@ -187,7 +186,7 @@ class OpencastHelper extends AbstractOnlineMediaHelper
             $url = $this->host . 'search/episode.json?id=' . $mediaId;
             if ($json = GeneralUtility::getUrl($url)) {
                 $json = json_decode($json, true);
-                if (is_array($json['search-results']) &&
+                if (isset($json['search-results']['result']) &&
                     is_array($json['search-results']['result'])) {
                     return $json['search-results']['result'];
                 }

--- a/Classes/Helpers/OpencastHelper.php
+++ b/Classes/Helpers/OpencastHelper.php
@@ -174,6 +174,13 @@ class OpencastHelper extends AbstractOnlineMediaHelper
         return null;
     }
 
+    /**
+     * See docs for details on API endpoint:
+     * https://stable.opencast.org/docs.html?path=/search#episodes-1
+     *
+     * @param  string $mediaId
+     * @return array
+     */
     protected function fetchJson($mediaId): ?array
     {
         if (preg_match('/' . self::MEDIA_ID_PATTERN . '/', $mediaId)) {


### PR DESCRIPTION
This patch fetches all sorts of meta data from the remove server (via `search/episode.json`) and writes it into the `sys_file_metadata` table. Additionally a preview image is fetched and written to `typo3temp/assets/online_media`.